### PR TITLE
Fix device

### DIFF
--- a/saliency/fullgrad.py
+++ b/saliency/fullgrad.py
@@ -31,7 +31,7 @@ class FullGrad():
 
         """
 
-        cuda = torch.cuda.is_available()
+        cuda = next(self.model.parameters()).is_cuda
         device = torch.device("cuda" if cuda else "cpu")
 
         #Random input image


### PR DESCRIPTION
Just a quick bugfix. This [line](https://github.com/idiap/fullgrad-saliency/blob/2121d212494d8dc401e27ec8198551efe68dd58f/saliency/fullgrad.py#L34) should be instead:

```python
cuda = next(self.model.parameters()).is_cuda
```

to avoid errors when cuda is available but the model has been purposefully been loaded on cpu:

```console
RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same
```

Thanks for he nice repo!